### PR TITLE
Add variables `github.event_name` `github.event.*`, similar to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,8 @@ The variables available in the `if` section are as follows
 | `day` | `int` | Day of current time (UTC) |
 | `hour` | `int` | Hour of current time (UTC) |
 | `weekday` | `int` | Weekday of current time (UTC) (Sunday = 0, ...) |
-| `github_event_name` | `string` | Event name of GitHub Actions ( ex. `issues`, `pull_request` )|
-| `github_event_action` | `string` | Action name of event ( ex. `opened` `closed` ) |
+| `github.event_name` | `string` | Event name of GitHub Actions ( ex. `issues`, `pull_request` )|
+| `github.event.*` | `map` | Detailed data for each event of GitHub Actions (ex. `github.event.action`, `github.event.label.name` ) |
 
 #### `tasks[*].env:`
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -239,6 +239,10 @@ func (r *Runner) CheckIf(cond string, i *target.Target) bool {
 		"github_event_name":   r.event.Name,
 		"github_event_action": r.event.Action,
 		"is_called":           isCalled,
+		"github": map[string]interface{}{
+			"event_name": r.event.Name,
+			"event":      r.event.Payload,
+		},
 	}
 	for _, k := range propagatableEnv {
 		v := os.Getenv(k)
@@ -443,10 +447,11 @@ func (r *Runner) revertEnv() error {
 }
 
 type GitHubEvent struct {
-	Name   string
-	Action string
-	Number int
-	State  string
+	Name    string
+	Action  string
+	Number  int
+	State   string
+	Payload interface{}
 }
 
 func decodeGitHubEvent() (*GitHubEvent, error) {
@@ -482,6 +487,15 @@ func decodeGitHubEvent() (*GitHubEvent, error) {
 		i.Number = s.Issue.Number
 		i.State = s.Issue.State
 	}
+
+	var payload interface{}
+
+	if err := json.Unmarshal(b, &payload); err != nil {
+		return i, err
+	}
+
+	i.Payload = payload
+
 	return i, nil
 }
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -45,15 +45,25 @@ func TestCheckIf(t *testing.T) {
 		},
 		{
 			`github_event_name
-==
-'issues'
-&&
-'question'
-in
-caller_action_labels_updated`,
+		==
+		'issues'
+		&&
+		'question'
+		in
+		caller_action_labels_updated`,
 			map[string]string{
 				"GITHUB_EVENT_NAME":           "issues",
 				"GHDAG_ACTION_LABELS_UPDATED": "bug question",
+			},
+			true,
+		},
+		{
+			`github.event_name == 'issues'
+		&& github.event.action == 'opened'
+		&& github.event.issue.state == 'open'`,
+			map[string]string{
+				"GITHUB_EVENT_NAME": "issues",
+				"GITHUB_EVENT_PATH": filepath.Join(testdataDir(), "event_issue_opened.json"),
 			},
 			true,
 		},


### PR DESCRIPTION
:octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat:  :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat:  :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat:  :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat:  :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat: :octocat:  