### PR TITLE
Remove variables `code_owners` `code_owners_who_approved`

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,7 @@ The variables available in the `if` section are as follows
 | `labels` | `array` | Labels that are set for the issue |
 | `assignees` | `array` | Assignees of the issue (pull request) |
 | `reviewers` | `array` | Reviewers of the pull request (including code owners) |
-| `code_owners` | `array` | Code owners of the pull request |
 | `reviewers_who_approved` | `array` | Reviewers who approved the pull request (including code owners) |
-| `code_owners_who_approved` | `array` | Code owners who approved the pull request |
 | `is_issue` | `bool` | `true` if the target type of the workflow is "Issue" |
 | `is_pull_request` | `bool` | `true` if the target type of the workflow is "Pull request" |
 | `is_approved` | `bool` | `true` if the pull request has been approved ( `Require pull request reviews before merging` option must be enabled ) |

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -137,7 +137,6 @@ type pullRequestNode struct {
 	ReviewDecision githubv4.PullRequestReviewDecision
 	ReviewRequests struct {
 		Nodes []struct {
-			AsCodeOwner       githubv4.Boolean
 			RequestedReviewer struct {
 				User struct {
 					Login githubv4.String
@@ -539,7 +538,6 @@ func buildTargetFromPullRequest(login string, p pullRequestNode, now time.Time) 
 		assignees = append(assignees, string(a.Login))
 	}
 	reviewers := []string{}
-	codeOwners := []string{}
 	for _, r := range p.ReviewRequests.Nodes {
 		var k string
 		if r.RequestedReviewer.User.Login != "" {
@@ -549,12 +547,8 @@ func buildTargetFromPullRequest(login string, p pullRequestNode, now time.Time) 
 			k = fmt.Sprintf("%s/%s", string(r.RequestedReviewer.Team.Organization.Login), string(r.RequestedReviewer.Team.Slug))
 		}
 		reviewers = append(reviewers, k)
-		if bool(r.AsCodeOwner) {
-			codeOwners = append(codeOwners, k)
-		}
 	}
 	reviewersWhoApproved := []string{}
-	codeOwnersWhoApproved := []string{}
 	for _, r := range p.LatestReviews.Nodes {
 		u := string(r.Author.Login)
 		reviewers = append(reviewers, u)
@@ -562,9 +556,6 @@ func buildTargetFromPullRequest(login string, p pullRequestNode, now time.Time) 
 			continue
 		}
 		reviewersWhoApproved = append(reviewersWhoApproved, u)
-		if contains(codeOwners, u) {
-			codeOwnersWhoApproved = append(codeOwnersWhoApproved, u)
-		}
 	}
 
 	return &target.Target{
@@ -577,9 +568,7 @@ func buildTargetFromPullRequest(login string, p pullRequestNode, now time.Time) 
 		Labels:                      labels,
 		Assignees:                   assignees,
 		Reviewers:                   unique(reviewers),
-		CodeOwners:                  codeOwners,
 		ReviewersWhoApproved:        reviewersWhoApproved,
-		CodeOwnersWhoApproved:       codeOwnersWhoApproved,
 		IsIssue:                     false,
 		IsPullRequest:               true,
 		IsApproved:                  isApproved,


### PR DESCRIPTION
see: https://github.community/t/how-can-i-query-about-code-owners-for-a-pr/14202

Unfortunately, I've decided that I can't get the Code owners that need to be reviewed in the Pull Request.